### PR TITLE
Add Samir Kakkar as meeting-notes maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @iamsamirzon

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Samir Kakkar <iamsamir@amazon.com> (@iamsamirzon)


### PR DESCRIPTION
Add Samir Kakkar as a seed maintainer of meeting-notes based on their activity and as per - https://github.com/notaryproject/meeting-notes/issues/5

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>