### PR TITLE
Add Pritesh Bandi as meeting-notes maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @priteshbandi

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)


### PR DESCRIPTION
Add Pritesh Bandi as a seed maintainer of meeting-notes based on their activity and as per - https://github.com/notaryproject/meeting-notes/issues/5

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>