### PR TITLE
Add Vani Rao as meeting-notes maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vaninrao10

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Vani Rao <vaninrao@amazon.com> (@vaninrao10)


### PR DESCRIPTION
Add Vani Rao as a seed maintainer of meeting-notes based on their activity and as per - https://github.com/notaryproject/meeting-notes/issues/5

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>