### PR TITLE
Added CODEOWNERS and MAINTAINERS files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Org-Level Owners (in alphabetical order)
+* @justincormack 
+* @niazfk
+* @stevelasker
+
+# Repo-Level Owners (in alphabetical order)
+# Note: This is only for the notaryproject/meeting-notes repo
+* @FeynmanZhou
+* @iamsamirzon
+* @priteshbandi
+* @toddysm
+* @vaninrao10
+* @yizha1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,3 @@
-# Org-Level Owners (in alphabetical order)
-* @justincormack 
-* @niazfk
-* @stevelasker
-
 # Repo-Level Owners (in alphabetical order)
 # Note: This is only for the notaryproject/meeting-notes repo
-* @FeynmanZhou
-* @iamsamirzon
-* @priteshbandi
-* @toddysm
-* @vaninrao10
-* @yizha1
+* @FeynmanZhou  @iamsamirzon @justincormack @niazfk @priteshbandi @stevelasker @toddysm @vaninrao10 @yizha1

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,14 @@
+# Org-Level Maintainers (in alphabetical order)
+# Pattern: [First Name] [Last Name] <[Email Address]> ([GitHub Handle])
+Justin Cormack <justin.cormack@docker.com> (@justincormack)
+Niaz Khan <niazfk@amazon.com> (@niazfk)
+Steve Lasker <StevenLasker@hotmail.com> (@stevelasker)
+
+# Repo-Level Maintainers (in alphabetical order)
+# Note: This is for the notaryproject/meeting-notes repo
+Feynman Zhou <feynmanzhou@microsoft.com> (@FeynmanZhou)
+Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)
+Samir Kakkar <iamsamir@amazon.com> (@iamsamirzon)
+Toddy Mladenov <toddysm@gmail.com> (@toddysm)
+Vani Rao <vaninrao@amazon.com> (@vaninrao10)
+Yi Zha <yizha1@microsoft.com> @yizha1


### PR DESCRIPTION
Signed-off-by: Toddy Mladenov <toddysm@gmail.com>

This PR combines all the changes from the following PRs for updating the maintainers for *notaryproject/meeting-notes* sub-project:
[Add Feynman Zhou](https://github.com/notaryproject/meeting-notes/pull/9) #9    
[Add Pritesh Bandi](https://github.com/notaryproject/meeting-notes/pull/7) #7    
[Add Samir Kakkar](https://github.com/notaryproject/meeting-notes/pull/6) #6    
[Add Toddy Mladenov](https://github.com/notaryproject/meeting-notes/pull/10) #10    
[Add Vani Rao](https://github.com/notaryproject/meeting-notes/pull/8) #8    
[Add Yi Zha](https://github.com/notaryproject/meeting-notes/pull/11) #11 

The proposal is to abandon the above PRs and merge only this one.