### PR TITLE
doc: update reference Notary v2 to Notary Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Archive of Meeting Notes from Hackmd.io
 
-Active notes are captured at [Notary v2 Meeting Notes](https://hackmd.io/_vrqBGAOSUC_VWvFzWruZw?view)
+Active notes are captured at [Notary Project Meeting Notes](https://hackmd.io/_vrqBGAOSUC_VWvFzWruZw?view)
 
 To avoid Hackmd having to index historical content, yearly archives will be moved here.
 
-- [Notary v2 Meeting Notes - 2021 Archive](./meeting-notes-2021.md)
-- [Notary v2 Meeting Notes - 2020 Archive](./meeting-notes-2020.md)
-- [Notary v2 Meeting Notes - 2019 Archive](./meeting-notes-2019.md)
+- [Notary Project Meeting Notes - 2021 Archive](./meeting-notes-2021.md)
+- [Notary Project Meeting Notes - 2020 Archive](./meeting-notes-2020.md)
+- [Notary Project Meeting Notes - 2019 Archive](./meeting-notes-2019.md)


### PR DESCRIPTION
As per agreement on [the comment](https://github.com/notaryproject/roadmap/issues/89#issuecomment-1477157871), change the wording `Notary v2` to `Notary Project` in `readme.md`. The content of archived meeting notes is not changed.

Signed-off-by: Yi Zha <yizha1@microsoft.com>